### PR TITLE
Fixed it trying to pull ztn from domain 3. 

### DIFF
--- a/ramscube/ramscube.py
+++ b/ramscube/ramscube.py
@@ -307,7 +307,7 @@ def add_dim_coordinates(filename, variable,variable_cube,variable_dict, coord_di
     if (variable_dict[variable]==3):
         time_coord=make_time_coord(coord_dict)
         variable_cube.add_aux_coord(time_coord)
-        z_coord=coords.DimCoord(coord_dict['ztn03'], standard_name='geopotential_height', long_name='z', var_name='z', units='m', bounds=None, attributes=None, coord_system=coord_system)
+        z_coord=coords.DimCoord(coord_dict['ztn01'], standard_name='geopotential_height', long_name='z', var_name='z', units='m', bounds=None, attributes=None, coord_system=coord_system)
         variable_cube.add_dim_coord(z_coord,0)
         model_level_number_coord=make_model_level_number_coordinate(len(z_coord.points))
         variable_cube.add_aux_coord(model_level_number_coord,0)


### PR DESCRIPTION
The code looks for ztn03 for its z coordinate currently. As not all RAMS simulations will have a 3rd grid, I've changed this to ztn01. From my understanding, when completing a RAMS simulation on multiple grids, all must have the same z coordinate anyway, so this should be functionally the same for simulations with multiple grids. 